### PR TITLE
Fixed inconsistent path to OS installation image for virtualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ From the host Mac, serve the installable image to the guest vm by editing `/etc/
 
 On the host Mac, link the image to the default Apache Web server directory:
 
-	$ sudo ln ~/Desktop/sierra.dmg /Library/WebServer/Documents
+	$ sudo ln ~/sierra.dmg /Library/WebServer/Documents
 
 From the host Mac, start Apache in the foreground:
 


### PR DESCRIPTION
The command to "link the image to the default Apache Web server directory" has an invalid path-to-file when following previous steps to create the macOS image for installation in virtual machine (previous step was "restore the image to the new volume": $ sudo asr restore --source ~/Desktop/sierra.dmg --target /Volumes/macOS --erase --buffersize").